### PR TITLE
feat(launcher) spawn the clients detached

### DIFF
--- a/libs/jar-executor.js
+++ b/libs/jar-executor.js
@@ -69,7 +69,11 @@ module.exports = async function (deps) {
     function executeJar(commandArgs, dialog) {
         log.info(`java ${commandArgs.join(' ')}`);
 
-        const jarProcess = spawn('java', commandArgs);
+        // execute it detached so when closing the launcher, doesn't close the clients.
+        const jarProcess = spawn('java', commandArgs, {
+        	detached: true,
+        	stdio: ['ignore', 'pipe', 'pipe']
+    	});
 
         jarProcess.stdout.on('data', (data) => {
             log.info(`[stdout] ${data}`);


### PR DESCRIPTION
using the detached option for spawn library makes so when closing the launcher, it doesnt close the open clients.