### PR TITLE
Prevent rejection on the OAuth flow after it succeeds, improve logic around select elements

### DIFF
--- a/libs/oauth-jagex.js
+++ b/libs/oauth-jagex.js
@@ -215,6 +215,7 @@ async function writeAccountsToFile(sessionId) {
  */
 async function startAuthFlow() {
     return new Promise(async (resolve, reject) => {
+        let finished = false;
         const availableBrowser = await getAvailableBrowser();
 
         if (!availableBrowser) {
@@ -238,6 +239,7 @@ async function startAuthFlow() {
          * Handles the unexpected closure of the authentication flow.
          */
         page.once('close', () => {
+            if (finished) return;
             browser.close();
             reject(new Error('Authentication flow closed unexpectedly.'));
         });
@@ -260,6 +262,7 @@ async function startAuthFlow() {
                         console.log(
                             'Authentication flow complete. Closing browser.'
                         );
+                        finished = true;
                         await browser.close();
                         resolve('Authentication successful.');
                     }


### PR DESCRIPTION
This pull request introduces improvements to the authentication flow and enhances the UI logic for handling accounts and client jar selection. The main changes focus on making the authentication process more robust and ensuring that client jars are displayed in version order, with additional logic to improve the user experience when accounts change.

**Authentication flow robustness:**

* Added a `finished` flag in `startAuthFlow` (in `libs/oauth-jagex.js`) to prevent multiple closures or rejections if the authentication browser window is closed unexpectedly or after successful authentication. This ensures proper cleanup and error handling. [[1]](diffhunk://#diff-f7c0055cb818018e8e729f04088847d2009f3dce82059c5bccf5e23d2584275aR218) [[2]](diffhunk://#diff-f7c0055cb818018e8e729f04088847d2009f3dce82059c5bccf5e23d2584275aR242) [[3]](diffhunk://#diff-f7c0055cb818018e8e729f04088847d2009f3dce82059c5bccf5e23d2584275aR265)

**UI improvements for account and client jar handling:**

* Implemented `orderClientJarsByVersion` in `renderer.js` to sort client jar files from latest to oldest based on version numbers, and updated both initialization and file change handling logic to use this ordered list when populating the client selector. [[1]](diffhunk://#diff-8a8d77cf15b2eaf50ec617c3603313fe363eaef34d8eb3c20ce12b607da55f04L469-R486) [[2]](diffhunk://#diff-8a8d77cf15b2eaf50ec617c3603313fe363eaef34d8eb3c20ce12b607da55f04R579-R605)
* Enhanced the account change detection logic in the periodic file checker: when the number of accounts changes, the selected character is updated to the latest account; otherwise, the previously selected character is preserved. This provides a smoother experience when accounts are added or removed.