### PR TITLE
feat: add Linux build workflow for AppImage creation and deployment

### DIFF
--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -1,0 +1,62 @@
+name: Build and Upload
+
+on:
+  push:
+    branches: [main]
+
+permissions:
+  contents: write
+
+jobs:
+  build-linux:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - run: npm ci
+
+      - name: Build AppImage
+        run: npm run linux
+
+      - name: Upload AppImage
+        uses: actions/upload-artifact@v4
+        with:
+          name: microbot-launcher-linux-latest
+          path: dist/*.AppImage
+
+  upload:
+    runs-on: ubuntu-latest
+    needs: [build-linux]
+
+    steps:
+      - name: Download Linux artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: microbot-launcher-linux-latest
+          path: ./linux
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: v${{ needs.build-win.outputs.version }}
+          name: Release v${{ needs.build-win.outputs.version }}-LINUX
+          files: |
+            ./linux/*.AppImage
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+
+      - name: Upload to Hetzner
+        env:
+          SSH_KEY: ${{ secrets.PROD_SSH_KEY }}
+        run: |
+          mkdir -p ~/.ssh
+          echo "$SSH_KEY" > ~/.ssh/id_rsa
+          chmod 600 ~/.ssh/id_rsa
+          ssh-keyscan -H 138.201.81.246 >> ~/.ssh/known_hosts
+          
+          # Upload AppImage
+          scp -r ./linux/*.AppImage root@138.201.81.246:/var/www/files/releases/microbot-launcher/

--- a/.github/workflows/build-mac.yml
+++ b/.github/workflows/build-mac.yml
@@ -56,7 +56,7 @@ jobs:
               uses: softprops/action-gh-release@v2
               with:
                   tag_name: v${{ steps.version.outputs.version }}
-                  name: Release v${{ steps.version.outputs.version }}
+                  name: Release v${{ steps.version.outputs.version }}-MAC
                   files: ${{ steps.find_dmg.outputs.dmg_path }}
               env:
                   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -53,30 +53,9 @@ jobs:
             libs/**
             index.html
             renderer.js
-
-  build-linux:
-    runs-on: ubuntu-latest
-    needs: build-win
-    steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
-        with:
-          node-version: 20
-
-      - run: npm ci
-
-      - name: Build AppImage
-        run: npm run linux
-
-      - name: Upload AppImage
-        uses: actions/upload-artifact@v4
-        with:
-          name: microbot-launcher-linux-latest
-          path: dist/*.AppImage
-
   upload:
     runs-on: ubuntu-latest
-    needs: [build-win, build-linux]
+    needs: [build-win]
 
     steps:
       - name: Download Windows artifact
@@ -84,12 +63,6 @@ jobs:
         with:
           name: microbot-launcher-exe-latest
           path: ./artifact
-
-      - name: Download Linux artifact
-        uses: actions/download-artifact@v4
-        with:
-          name: microbot-launcher-linux-latest
-          path: ./linux
 
       - name: Download assets
         uses: actions/download-artifact@v4
@@ -101,7 +74,7 @@ jobs:
         uses: softprops/action-gh-release@v2
         with:
           tag_name: v${{ needs.build-win.outputs.version }}
-          name: Release v${{ needs.build-win.outputs.version }}
+          name: Release v${{ needs.build-win.outputs.version }}-WINDOWS
           files: |
             ./artifact/Microbot Launcher Setup.exe
             ./artifact/latest.yml
@@ -121,9 +94,6 @@ jobs:
 
           # Upload EXE
           scp -r ./artifact/* root@138.201.81.246:/var/www/files/releases/microbot-launcher/
-
-          # Upload AppImage
-          scp -r ./linux/*.AppImage root@138.201.81.246:/var/www/files/releases/microbot-launcher/
 
           # Upload additional files
           scp -r \


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Chores
  - Introduced a dedicated Linux build and release pipeline that publishes a Linux AppImage and attaches it to GitHub Releases.
  - Windows releases now include only Windows artifacts; Linux assets are handled in the Linux pipeline.
  - Release titles now clearly indicate the platform with suffixes (-WINDOWS, -MAC) for easier identification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->