### PR TITLE
API Version Update Workflow 

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -41,3 +41,32 @@ jobs:
                       ./artifacts/microbot-launcher-mac-latest/*.dmg
               env:
                   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+            - name: Get Auth Token (Launcher Version Update)
+              id: auth
+              run: |
+                  set -euo pipefail
+                  RESPONSE=$(curl -s -X POST \
+                      -H "Content-Type: application/json" \
+                      -d "{\"email\":\"${{ secrets.API_EMAIL }}\",\"password\":\"${{ secrets.API_PASSWORD }}\"}" \
+                      https://microbot.cloud/api/auth/login)
+                  echo "Raw auth response: $RESPONSE" | sed 's/.*/[debug] &/'
+                  TOKEN=$(echo "$RESPONSE" | jq -r '.token // empty')
+                  if [ -z "$TOKEN" ] || [ "$TOKEN" = "null" ]; then
+                      echo "::error::Failed to obtain auth token"; exit 1; fi
+                  echo "token=$TOKEN" >> $GITHUB_OUTPUT
+
+            - name: Update Launcher Version in API
+              run: |
+                  set -euo pipefail
+                  VERSION=${{ steps.version.outputs.version }}
+                  echo "Updating launcher version to $VERSION via API"
+                  HTTP_CODE=$(curl -s -o response.json -w "%{http_code}" -X PUT \
+                      -H "Authorization: Bearer ${{ steps.auth.outputs.token }}" \
+                      -H "Content-Type: application/json" \
+                      -d "{\"version\":\"$VERSION\"}" \
+                      https://microbot.cloud/api/version/launcher)
+                  echo "API response (HTTP $HTTP_CODE):"; cat response.json || true
+                  if [ "$HTTP_CODE" -ge 200 ] && [ "$HTTP_CODE" -lt 300 ]; then
+                      echo "Launcher version updated successfully"; else
+                      echo "::error::Failed to update launcher version (HTTP $HTTP_CODE)"; exit 1; fi

--- a/main.js
+++ b/main.js
@@ -184,7 +184,7 @@ async function createWindow() {
             .children('script')
             .last()
             .replaceWith(
-                '<script src="https://files.microbot.cloud/assets/microbot-launcher/renderer.js?version=3.1.8"></script>'
+                '<script src="https://files.microbot.cloud/assets/microbot-launcher/renderer.js?version=3.1.9"></script>'
             );
         $('head')
             .children('link[rel="stylesheet"]')

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "microbot-launcher",
-  "version": "3.1.8",
+  "version": "3.1.9",
   "description": "Launcher for the microbot client",
   "main": "main.js",
   "scripts": {


### PR DESCRIPTION
Currently, the Microbot landing page is not providing the latest version of the launcher due to the manual update requirement for the launcher version on the API. Unlike the Microbot client release workflow, we seem to be missing the step of updating the version on the API.

I suggest setting up the PUT endpoint for `https://microbot.cloud/api/version/launcher` and ensuring the required secrets are added to the repository before approving the PR 👍.

## Github Copilot Summary

This pull request introduces an automated update to the launcher version in both the application and the external API as part of the release workflow. The main changes include updating the renderer version and adding new steps to the GitHub Actions workflow to authenticate and update the launcher version via an API call.

**Release workflow automation:**

* [`.github/workflows/create-release.yml`](diffhunk://#diff-8ac33fe295df086d3e55df1eb01194819d34cc0f5f54076dba96ceac0e40bd79R44-R72): Added steps to obtain an authentication token using API credentials and to update the launcher version in the external API after a new release is created. These steps ensure the API always reflects the latest launcher version.

**Version update:**

* [`main.js`](diffhunk://#diff-58417e0f781b6656949d37258c8b9052ed266e2eb7a5163cad7b0863e6b2916aL187-R187): Updated the `renderer.js` script reference from version `3.1.8` to `3.1.9` to use the latest assets in the application window.- Bump version to 3.1.9
This pull request introduces a new step in the release workflow to automatically update the launcher version in the remote API after a release, and bumps the application version to 3.1.9. The workflow now authenticates with the API and updates the version, ensuring consistency between the released binary and the backend version record.

Release workflow automation:

* [`.github/workflows/create-release.yml`](diffhunk://#diff-8ac33fe295df086d3e55df1eb01194819d34cc0f5f54076dba96ceac0e40bd79R44-R72): Adds steps to authenticate with the remote API and update the launcher version after a release is created. This includes obtaining an auth token and making a PUT request to update the version.

Version bump:

* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L3-R3): Updates the application version from 3.1.8 to 3.1.9.
* [`main.js`](diffhunk://#diff-58417e0f781b6656949d37258c8b9052ed266e2eb7a5163cad7b0863e6b2916aL187-R187): Updates the referenced renderer script to use the new version (3.1.9).